### PR TITLE
Handle autoplay failure in startCamera

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,9 +155,14 @@
             mediaStream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" }, audio: false });
             VIDEO.srcObject = mediaStream;
           }
-          await VIDEO.play().catch(err => console.warn('Autoplay blockiert', err));
-          statusEl.textContent = 'Kamera aktiv';
-          run();
+          try {
+            await VIDEO.play();
+            statusEl.textContent = 'Kamera aktiv';
+            run();
+          } catch (err) {
+            statusEl.textContent = 'Autoplay blockiert: ' + err.message;
+            console.warn('Autoplay blockiert', err);
+          }
         };
 
       } catch (err) {


### PR DESCRIPTION
## Summary
- handle autoplay failures in startCamera's video setup
- avoid launching pose loop when video playback fails

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f3383463083279ffbedf8d4e192e3