### PR TITLE
Keep video element in layout for Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,10 @@
     </div>
   </main>
 
-  <video id="video" style="display:none" playsinline muted></video>
+  <!-- Safari requires the video element to remain in the layout so that frames
+       can be rendered to the canvas. Instead of using display:none, move the
+       element off-screen and make it transparent. -->
+  <video id="video" style="opacity:0; position:absolute; left:-9999px; top:-9999px;" playsinline muted></video>
 
   <script>
     const CANVAS = document.getElementById('canvas');


### PR DESCRIPTION
## Summary
- Avoid `display:none` on hidden video element so Safari renders camera frames to canvas

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f368db2708327a930f69148cefdc7